### PR TITLE
[Bugfix|Feature] 接友盟推送和修复启动页拉伸

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ android {
         secret.buildConfigField.forEach({ k, v ->
             buildConfigField("String", k, v)
         })
+
+        ndk {
+            abiFilters 'armeabi'
+            abiFilters 'x86'
+        }
+
     }
 
     dexOptions {


### PR DESCRIPTION
describtion：接入友盟通知栏消息和应用类消息，闪屏页全屏消息因继承关系无法使用非暴力手段接入，优化启动页的拉伸问题，添加lzx课表忘加代码

Signed-off-by: Jon <1246634075@qq.com>